### PR TITLE
Add contribution guidelines, and pr template

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,90 @@
+# Contributing to generator-helix
+
+:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:
+
+The following is a set of guidelines for contributing to generator-helix and its packages, which are hosted in the [PentiaLabs](https://github.com/PentiaLabs) on GitHub.
+These are just guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+
+#### Table Of Contents
+
+[What should I know before I get started?](#what-should-i-know-before-i-get-started)
+  * [Build with Yeoman](#build-with-yeoman)
+
+[How Can I Contribute?](#how-can-i-contribute)
+  * [Reporting Bugs](#reporting-bugs)
+  * [Suggesting Enhancements](#suggesting-enhancements)
+  * [Pull Requests](#pull-requests)
+
+## What should I know before I get started?
+
+### Build with Yeoman
+
+This project, generator-helix, is build with [Yeoman](http://yeoman.io/). Yeoman helps you to kickstart new projects, prescribing best practices and tools to help you stay productive.
+
+To do so, it provides a generator ecosystem. A generator is basically a plugin that can be run with the `yo` command to scaffold complete projects or useful parts.
+
+Inside we're utilizing the "Yeoman workflow". This workflow is a robust and opinionated client-side stack, comprising tools and frameworks that can help developers quickly build applications. We take care of providing everything needed to get started without any of the normal headaches associated with a manual setup.
+
+It would be wise to read up on the basics of Yeoman to get an understanding on the concepts before diving into contributing to the project.
+
+## How Can I Contribute?
+
+### Reporting Bugs
+
+This section guides you through submitting a bug report for generator-helix. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer: :computer:, and find related reports :mag_right:.
+
+When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report). Fill out [the required template](ISSUE_TEMPLATE.md), the information it asks for helps us resolve issues faster.
+
+#### How Do I Submit A (Good) Bug Report?
+
+Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/). Create an issue in this repository and provide the following information by filling in [the template](ISSUE_TEMPLATE.md).
+
+Explain the problem and include additional details to help maintainers reproduce the problem:
+
+* **Use a clear and descriptive title** for the issue to identify the problem.
+* **Describe the exact steps which reproduce the problem** in as many details as possible. For example, start by explaining how you started generator-helix, e.g. which command exactly you used in the terminal, or how you started it otherwise. When listing steps, **don't just say what you did, but explain how you did it**.
+* **Provide specific examples to demonstrate the steps**. Include links to files or GitHub projects, or copy/pasteable snippets, which you use in those examples. If you're providing snippets in the issue, use [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
+* **Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
+* **Explain which behavior you expected to see instead and why.**
+* **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem. You can use [this tool](http://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
+
+Provide more context by answering these questions:
+
+* **Did the problem start happening recently** (e.g. after updating to a new version of generator-helix) or was this always a problem?
+* If the problem started happening recently, **can you reproduce the problem in an older version of generator-helix?** What's the most recent version in which the problem doesn't happen? You can download older versions of generator-helix from [the releases page](https://github.com/PentiaLabs/generator-helix/releases).
+* **Can you reliably reproduce the issue?** If not, provide details about how often the problem happens and under which conditions it normally happens.
+
+Include details about your configuration and environment:
+
+* **What's the name and version of the OS you're using**?
+* **What's the version of node installed**? You can get that number by running `node --version`.
+* **What's the version of npm installed**? You can get that number by running `npm --version`.
+
+### Suggesting Enhancements
+
+This section guides you through submitting an enhancement suggestion for generator-helix, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
+
+Fill in [the template](ISSUE_TEMPLATE.md), including the steps that you imagine you would take if the feature you're requesting existed.
+
+#### How Do I Submit A (Good) Enhancement Suggestion?
+
+Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com/features/issues/). Create an issue in this repository and provide the following information:
+
+* **Use a clear and descriptive title** for the issue to identify the suggestion.
+* **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
+* **Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
+* **Describe the current behavior** and **explain which behavior you expected to see instead** and why.
+* **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of generator-helix which the suggestion is related to. You can use [this tool](http://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
+* **Explain why this enhancement would be useful** to most generator-helix users.
+
+### Pull Requests
+
+* Write a convincing description of your PR and why it should land by filling in in [the required template](PULL_REQUEST_TEMPLATE.md)
+* Please check to make sure that there aren't existing pull requests attempting to address the issue mentioned.
+* Non-trivial changes should be discussed in an issue first.
+* Develop in a feature branch, not master.
+* Include screenshots and animated GIFs in your pull request whenever possible and neccessary.
+
+---
+
+Happy contributing! :love_hotel:

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+### Requirements
+
+* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
+
+### Description of the Change
+
+<!--
+
+We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.
+
+-->
+
+### Benefits
+
+<!-- What benefits will be realized by the code change? -->
+
+### Possible Drawbacks
+
+<!-- What are the possible side-effects or negative impacts of the code change? -->

--- a/readme.md
+++ b/readme.md
@@ -33,8 +33,12 @@ You can call with the Project Name, if you do not you will be prompted to enter 
 > yo helix:add [ProjectName]
 
 
-## Help us! Keep the quality of issues high
+## Contributing
 
-We strive to make it possible for everyone and anybody to contribute to this project. Please help us by making issues easier to resolve by providing sufficient information. Understanding the reasons behind issues can take a lot of time if information is left out. Time that we could rather spend on fixing bugs and adding features. Please adhere to our issues template when creating issues. Creating a new issues will automatically prompt a template that will let you know what the minimum requirements are.
+We love it if you would contribute! **Please read our [contributing guide](CONTRIBUTING.md) if you're looking to help us out.**
+
+**Help us! Keep the quality of feature requests and bug reports high**
+
+We strive to make it possible for everyone and anybody to contribute to this project. Please help us by making issues easier to resolve by providing sufficient information. Understanding the reasons behind issues can take a lot of time if information is left out. Time that we could rather spend on fixing bugs and adding features. Please adhere to our [issues template](ISSUE_TEMPLATE.md) when creating issues. Creating a new issues will automatically prompt a template that will let you know what the minimum requirements are.
 
 Thank you, and happy contributing!


### PR DESCRIPTION
### Description of the Change

To make sure we get feature requests, issues, pull requests etc.
in as high quality as possible and to make everyone capable of
resolving them, I've added a set of contribution guidelines to let
contributors know what's expected of them.

Scope: docs, contributing, repository.

### Benefits

Other than that we'll have a clear and consise position on what's expected for contributors, the contributing.md will be visible when creating new issues (as you can see an example of here [here](https://github.com/blog/1184-contributing-guidelines)) and I've also created a PR-template that will prefill the textarea when people are submitting new pull requests.

### Possible Drawbacks

It might take longer for people to get into contributing, but the heightened quality will pay for that ;-)