### PR TITLE
Provide instructions on Execution Policy resolving

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,6 @@ You can call with the Project Name, if you do not you will be prompted to enter 
 
 > yo helix:add [ProjectName]
 
-
 ## Contributing
 
 We love it if you would contribute! **Please read our [contributing guide](CONTRIBUTING.md) if you're looking to help us out.**
@@ -42,3 +41,11 @@ We love it if you would contribute! **Please read our [contributing guide](CONTR
 We strive to make it possible for everyone and anybody to contribute to this project. Please help us by making issues easier to resolve by providing sufficient information. Understanding the reasons behind issues can take a lot of time if information is left out. Time that we could rather spend on fixing bugs and adding features. Please adhere to our [issues template](ISSUE_TEMPLATE.md) when creating issues. Creating a new issues will automatically prompt a template that will let you know what the minimum requirements are.
 
 Thank you, and happy contributing!
+
+## Troubleshooting
+
+*When I execute the `yo` commands as described I'm met with Execution Policy errors*
+
+To get around this issues execute the following command in a command line prompt, such as PowerShell with administrator rights:
+
+> Set-ExecutionPolicy Unrestricted -Scope CurrentUser -Force 


### PR DESCRIPTION
### Description of the Change

Users governed by insufficient execution policy settings
might need some help on how to change policies to fit the
use of this project. These instructions are now enclosed in the
README in a new section called troubleshooting.

Scope: Docs, instructions.
Fix: #49

### Benefits

It will be clearer for people to sort out any issues they have with insufficient Execution Policies.

### Possible Drawbacks

There shouldn't be any.