### PR TITLE
fixes #2 - add template functionality for adding projects

### DIFF
--- a/generators/add/index.js
+++ b/generators/add/index.js
@@ -128,6 +128,15 @@ module.exports = class extends yeoman {
         });
    }
 
+   _copySolutionSpecificItems(){
+      fs.access(this.destinationPath('helix-template'), fs.constants.R_OK, (err) => {
+            if(err==null)
+            {
+                this.fs.copyTpl(this.destinationPath('helix-template/**/*'), this.destinationPath(this.settings.ProjectPath), this.templatedata);
+            }
+        }); 
+   }
+   
     _copySerializationItems() {
         mkdir.sync(path.join(this.settings.sourceFolder, this.layer, this.settings.ProjectName, 'serialization' ));
         var serializationDestinationFile = path.join(this.settings.ProjectPath, 'App_Config/Include', this.settings.LayerPrefixedProjectName, 'serialization.config');
@@ -137,6 +146,7 @@ module.exports = class extends yeoman {
     writing() {
           this.settings.ProjectPath = path.join(this.settings.sourceFolder, this.layer, this.settings.ProjectName, 'code' );
           this._copyProjectItems() 
+          this._copySolutionSpecificItems()
 
            if(this.settings.serialization)
            {

--- a/generators/add/index.js
+++ b/generators/add/index.js
@@ -2,164 +2,174 @@ var yeoman = require('yeoman-generator');
 var mkdir = require('mkdirp');
 var yosay = require('yosay');
 var guid = require('uuid');
-var powershell = require("../../modules/powershell");
-var fs = require("fs");
-var path = require("path");
+var powershell = require('../../modules/powershell');
+var fs = require('fs');
+var path = require('path');
 var chalk = require('chalk'); 
 
 module.exports = class extends yeoman {
 
-    constructor(args, opts) {
-        super(args, opts);
-        this.argument('ProjectName', { type: String, required: false, desc: 'Name of the project' });
-    }
+	constructor(args, opts) {
+		super(args, opts);
+		this.argument('ProjectName', { type: String, required: false, desc: 'Name of the project' });
+	}
 
-    init() {
-        this.log(yosay('Lets generate that project!'));
-        this.templatedata = {};
-    }
+	init() {
+		this.log(yosay('Lets generate that project!'));
+		this.templatedata = {};
+	}
 
-    askForProjectSettings() {
-        var questions = [{
-                type: 'input',
-                name: 'ProjectName',
-                message: 'Name of your project.'+chalk.blue(" (Excluding layer prefix)"),
-                default: this.options.ProjectName
-            },
-            {
-                type: 'confirm',
-                name: 'serialization',
-                message: 'Would you like to include Unicorn (serialization)?',
-                default : true
-            },
-            {
-                type:'input',
-                name:'sourceFolder',
-                message:'Source code folder name', 
-                default: 'src'
-            }];
+	askForProjectSettings() {
+		var questions = [{
+			type: 'input',
+			name: 'ProjectName',
+			message: 'Name of your project.'+chalk.blue(' (Excluding layer prefix)'),
+			default: this.options.ProjectName
+		},
+		{
+			type: 'confirm',
+			name: 'serialization',
+			message: 'Would you like to include Unicorn (serialization)?',
+			default : true
+		},
+		{
+			type:'input',
+			name:'sourceFolder',
+			message:'Source code folder name', 
+			default: 'src'
+		}];
 
-        var done = this.async();
-        this.prompt(questions).then(function(answers) {
-            this.settings = answers;
-            this.settings.ProjectName = this.settings.ProjectName;
-            done();
-        }.bind(this));
-    }
+		var done = this.async();
+		this.prompt(questions).then(function(answers) {
+			this.settings = answers;
+			this.settings.ProjectName = this.settings.ProjectName;
+			done();
+		}.bind(this));
+	}
 
-   askForLayer() {
-        var questions = [{
-        type: 'list',
-        name: 'layer',
-        message: 'What layer do you want to add the project too?',
-        choices: [
-            {
-            name: 'Feature layer?',
-            value: 'Feature'
-            }, {
-            name: 'Foundation layer?',
-            value: 'Foundation'
-            }, {
-            name: 'Project layer?',
-            value: 'Project'
-            }]
-        }];
+	askForLayer() {
+		var questions = [{
+			type: 'list',
+			name: 'layer',
+			message: 'What layer do you want to add the project too?',
+			choices: [
+				{
+					name: 'Feature layer?',
+					value: 'Feature'
+				}, {
+					name: 'Foundation layer?',
+					value: 'Foundation'
+				}, {
+					name: 'Project layer?',
+					value: 'Project'
+				}]
+		}];
 
-        var done = this.async();
-        this.prompt(questions).then(function(answers) {
-            this.layer = answers.layer;
-            this.settings.LayerPrefixedProjectName = this.layer + '.' + this.settings.ProjectName;
-            done();
-        }.bind(this));
-    }
+		var done = this.async();
+		this.prompt(questions).then(function(answers) {
+			this.layer = answers.layer;
+			this.settings.LayerPrefixedProjectName = this.layer + '.' + this.settings.ProjectName;
+			done();
+		}.bind(this));
+	}
 
-      askTargetFrameworkVersion() {
-        var questions = [{
-        type: 'list',
-        name: 'target',
-        message: 'Choose target .net framework version?',
-        choices: [
-            {
-            name: '.net 4.6.1',
-            value: 'v4.6.1'
-            }, {
-            name: '.net 4.6',
-            value: 'v4.6'
-            }, {
-            name: '.net 4.5.2',
-            value: 'v4.5.2'
-            }]
-        }];
+	askTargetFrameworkVersion() {
+		var questions = [{
+			type: 'list',
+			name: 'target',
+			message: 'Choose target .net framework version?',
+			choices: [
+				{
+					name: '.net 4.6.1',
+					value: 'v4.6.1'
+				}, {
+					name: '.net 4.6',
+					value: 'v4.6'
+				}, {
+					name: '.net 4.5.2',
+					value: 'v4.5.2'
+				}]
+		}];
 
-        var done = this.async();
-        this.prompt(questions).then(function(answers) {
-            this.target = answers.target;
-            this._buildTemplateData();
-            done();
-        }.bind(this));
-    }
+		var done = this.async();
+		this.prompt(questions).then(function(answers) {
+			this.target = answers.target;
+			this._buildTemplateData();
+			done();
+		}.bind(this));
+	}
 
-    _buildTemplateData() {
-        this.templatedata.layerprefixedprojectname = this.settings.LayerPrefixedProjectName;
-        this.templatedata.projectname = this.settings.ProjectName;
-        this.templatedata.projectguid = guid.v4();
-        this.templatedata.layer = this.layer;
-        this.templatedata.target = this.target;
-    }
+	_buildTemplateData() {
+		this.templatedata.layerprefixedprojectname = this.settings.LayerPrefixedProjectName;
+		this.templatedata.projectname = this.settings.ProjectName;
+		this.templatedata.projectguid = guid.v4();
+		this.templatedata.layer = this.layer;
+		this.templatedata.target = this.target;
+	}
 
-    _copyProjectItems() {
-        mkdir.sync(this.settings.ProjectPath);
-        if(this.settings.serialization)
+	_copyProjectItems() {
+		mkdir.sync(this.settings.ProjectPath);
+		if(this.settings.serialization)
         {
-            this.fs.copyTpl(this.templatePath('_project.unicorn.csproj'), this.destinationPath(path.join(this.settings.ProjectPath, this.settings.LayerPrefixedProjectName + '.csproj')), this.templatedata);
-        }
-        else
+			this.fs.copyTpl(this.templatePath('_project.unicorn.csproj'), this.destinationPath(path.join(this.settings.ProjectPath, this.settings.LayerPrefixedProjectName + '.csproj')), this.templatedata);
+		}
+		else
         {
-            this.fs.copyTpl(this.templatePath('_project.csproj'), this.destinationPath(path.join(this.settings.ProjectPath, this.settings.LayerPrefixedProjectName + '.csproj')), this.templatedata);
-        }
-        this.fs.copyTpl(this.templatePath('Properties/AssemblyInfo.cs'), this.destinationPath(path.join(this.settings.ProjectPath, '/Properties/AssemblyInfo.cs')), this.templatedata);
+			this.fs.copyTpl(this.templatePath('_project.csproj'), this.destinationPath(path.join(this.settings.ProjectPath, this.settings.LayerPrefixedProjectName + '.csproj')), this.templatedata);
+		}
+		this.fs.copyTpl(this.templatePath('Properties/AssemblyInfo.cs'), this.destinationPath(path.join(this.settings.ProjectPath, '/Properties/AssemblyInfo.cs')), this.templatedata);
         
         //if we have publishsettings.targets, then copy in PublishProfiles/local.pubxml
-        fs.access(this.destinationPath('publishsettings.targets'), fs.constants.R_OK, (err) => {
-            if(err==null)
+		fs.access(this.destinationPath('publishsettings.targets'), fs.constants.R_OK, (err) => {
+			if(err==null)
             {
-                this.fs.copyTpl(this.templatePath('Properties/PublishProfiles/local.pubxml'), this.destinationPath(path.join(this.settings.ProjectPath, 'Properties/PublishProfiles/local.pubxml')), this.templatedata);
-            }
-        });
-   }
+				this.fs.copyTpl(this.templatePath('Properties/PublishProfiles/local.pubxml'), this.destinationPath(path.join(this.settings.ProjectPath, 'Properties/PublishProfiles/local.pubxml')), this.templatedata);
+			}
+		});
+	}
 
-   _copySolutionSpecificItems(){
-      fs.access(this.destinationPath('helix-template'), fs.constants.R_OK, (err) => {
-            if(err==null)
-            {
-                this.fs.copyTpl(this.destinationPath('helix-template/**/*'), this.destinationPath(this.settings.ProjectPath), this.templatedata);
-            }
-        }); 
-   }
+	_copySolutionSpecificItems(){
+		this.fs.copyTpl(this.destinationPath('helix-template/**/*'), this.destinationPath(this.settings.ProjectPath), this.templatedata);
+	}
+
+	_renameProjectFile() {
+		fs.renameSync(this.destinationPath(path.join(this.settings.ProjectPath, '_project.csproj')), this.destinationPath(path.join(this.settings.ProjectPath, this.settings.LayerPrefixedProjectName + '.csproj')));
+	}
+
    
-    _copySerializationItems() {
-        mkdir.sync(path.join(this.settings.sourceFolder, this.layer, this.settings.ProjectName, 'serialization' ));
-        var serializationDestinationFile = path.join(this.settings.ProjectPath, 'App_Config/Include', this.settings.LayerPrefixedProjectName, 'serialization.config');
-        this.fs.copyTpl(this.templatePath('_serialization.config'), this.destinationPath(serializationDestinationFile), this.templatedata);
-     }
+	_copySerializationItems() {
+		mkdir.sync(path.join(this.settings.sourceFolder, this.layer, this.settings.ProjectName, 'serialization' ));
+		var serializationDestinationFile = path.join(this.settings.ProjectPath, 'App_Config/Include', this.settings.LayerPrefixedProjectName, 'serialization.config');
+		this.fs.copyTpl(this.templatePath('_serialization.config'), this.destinationPath(serializationDestinationFile), this.templatedata);
+	}
 
-    writing() {
-          this.settings.ProjectPath = path.join(this.settings.sourceFolder, this.layer, this.settings.ProjectName, 'code' );
-          this._copyProjectItems() 
-          this._copySolutionSpecificItems()
+	writing() {
+		this.settings.ProjectPath = path.join(this.settings.sourceFolder, this.layer, this.settings.ProjectName, 'code' );
+		this._copyProjectItems(); 
 
-           if(this.settings.serialization)
-           {
-               this._copySerializationItems();
-           }
+		if(this.settings.serialization)
+        {
+			this._copySerializationItems();
+		}
 
-           const files = fs.readdirSync( this.destinationPath())
-           const SolutionFile = files.find(file => file.indexOf('.sln') > -1)
-           const scriptParameters = "-SolutionFile '" + this.destinationPath(SolutionFile) + "' -Name " + this.settings.LayerPrefixedProjectName + " -Type " + this.layer + " -ProjectPath '" + this.settings.ProjectPath + "'" + " -SolutionFolderName " + this.templatedata.projectname;
+		if(fs.existsSync(this.destinationPath('helix-template')))
+        {
+			this._copySolutionSpecificItems();
+		}
 
-           var pathToAddProjectScript = path.join(this._sourceRoot, "../../../powershell/add-project.ps1");
-           powershell.runAsync(pathToAddProjectScript, scriptParameters);
+		const files = fs.readdirSync( this.destinationPath());
+		const SolutionFile = files.find(file => file.indexOf('.sln') > -1);
+		const scriptParameters = '-SolutionFile \'' + this.destinationPath(SolutionFile) + '\' -Name ' + this.settings.LayerPrefixedProjectName + ' -Type ' + this.layer + ' -ProjectPath \'' + this.settings.ProjectPath + '\'' + ' -SolutionFolderName ' + this.templatedata.projectname;
 
-        }
+		var pathToAddProjectScript = path.join(this._sourceRoot, '../../../powershell/add-project.ps1');
+		powershell.runAsync(pathToAddProjectScript, scriptParameters);
+
+	}
+
+	end() {
+		if(fs.existsSync(this.destinationPath('helix-template/_project.csproj')))
+        {
+			this._renameProjectFile();
+		}}
 };
 

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,24 @@ You can call with the Project Name, if you do not you will be prompted to enter 
 
 > yo helix:add [ProjectName]
 
+### Extending the add generator
+
+To extend the add generator create a folder in solution root called helix-template.
+All files in the folder are copied to the project folder using the copyTpl function in yeoman.
+This means that if you need to inject the data from the generator to your files you can use the variables like this.
+
+> <%= layerprefixedprojectname %> 
+
+**Variables**
+* layerprefixedprojectname 
+* projectname
+* projectguid
+* layer
+* target
+
+The one special case is that if you have a file called _project.csproj in the folder it will copy it and then rename it to the correct Project name.
+This way you can create your own project file that matches your specific needs.
+
 ## Contributing
 
 We love it if you would contribute! **Please read our [contributing guide](CONTRIBUTING.md) if you're looking to help us out.**


### PR DESCRIPTION
### Requirements

The requirement is as specified in issue #2 that we need a way to have solution specific files for being added on the add project generator. 

### Description of the Change

This introduces the convention that anything added under the folder helix-template folder is also copied when creating a new project. Its being copied using copyTpl so that people can use the variables from the yeoman generator. 

### Benefits

The benefits is that people can easily extend the generator to suit their specific solution without having to modify core functionality.

### Possible Drawbacks

This might introduce complexity that can make debugging issues with the generator harder. 