### PR TITLE
fix #60 - now removes spaces in configuration FullName

### DIFF
--- a/Powershell/Add-BuildConfigurations.ps1
+++ b/Powershell/Add-BuildConfigurations.ps1
@@ -9,7 +9,7 @@ Function Add-BuildConfigurations {
     $propertyGroupCondition = "</PropertyGroup>" 
     foreach ($configuration in $Configurations)
     {    
-        $configurationToAdd = $configuration.FullName
+        $configurationToAdd = $configuration.FullName.Replace(" ","")
         $addProjectBuildConfiguration = @("  <PropertyGroup Condition=`"'`$(Configuration)|`$(Platform)' == '$configurationToAdd'`">",
                                   "`t<DebugSymbols>true</DebugSymbols>",
                                   "`t<OutputPath>bin\</OutputPath>",


### PR DESCRIPTION
### Requirements

See #60  - the projects are not added with the correct Configuration name. Because the build configuration in the solution name is with a space and the ones specified in the project file needs to be without. 

### Description of the Change

When adding the project build configuraitons i just remove spaces from the build configuration.

### Benefits

This will ensure that the build configurations are seen correctly and used by visual studio.

### Possible Drawbacks

None-