### PR TITLE
Reformating and use ES6 syntax

### DIFF
--- a/generators/add/index.js
+++ b/generators/add/index.js
@@ -1,14 +1,13 @@
-var yeoman = require('yeoman-generator');
-var mkdir = require('mkdirp');
-var yosay = require('yosay');
-var guid = require('uuid');
-var powershell = require('../../modules/powershell');
-var fs = require('fs');
-var path = require('path');
-var chalk = require('chalk'); 
+const yeoman = require('yeoman-generator');
+const mkdir = require('mkdirp');
+const yosay = require('yosay');
+const guid = require('uuid');
+const powershell = require('../../modules/powershell');
+const fs = require('fs');
+const path = require('path');
+const chalk = require('chalk');
 
 module.exports = class extends yeoman {
-
 	constructor(args, opts) {
 		super(args, opts);
 		this.argument('ProjectName', { type: String, required: false, desc: 'Name of the project' });
@@ -20,10 +19,11 @@ module.exports = class extends yeoman {
 	}
 
 	askForProjectSettings() {
-		var questions = [{
+		let done = this.async();
+		let questions = [{
 			type: 'input',
 			name: 'ProjectName',
-			message: 'Name of your project.'+chalk.blue(' (Excluding layer prefix)'),
+			message: 'Name of your project.' + chalk.blue(' (Excluding layer prefix)'),
 			default: this.options.ProjectName
 		},
 		{
@@ -35,20 +35,19 @@ module.exports = class extends yeoman {
 		{
 			type:'input',
 			name:'sourceFolder',
-			message:'Source code folder name', 
+			message:'Source code folder name',
 			default: 'src'
 		}];
 
-		var done = this.async();
-		this.prompt(questions).then(function(answers) {
+		this.prompt(questions).then((answers) => {
 			this.settings = answers;
-			this.settings.ProjectName = this.settings.ProjectName;
 			done();
-		}.bind(this));
+		});
 	}
 
 	askForLayer() {
-		var questions = [{
+		const done = this.async();
+		const questions = [{
 			type: 'list',
 			name: 'layer',
 			message: 'What layer do you want to add the project too?',
@@ -65,16 +64,16 @@ module.exports = class extends yeoman {
 				}]
 		}];
 
-		var done = this.async();
-		this.prompt(questions).then(function(answers) {
+		this.prompt(questions).then((answers) => {
 			this.layer = answers.layer;
 			this.settings.LayerPrefixedProjectName = this.layer + '.' + this.settings.ProjectName;
 			done();
-		}.bind(this));
+		});
 	}
 
 	askTargetFrameworkVersion() {
-		var questions = [{
+		const done = this.async();
+		const questions = [{
 			type: 'list',
 			name: 'target',
 			message: 'Choose target .net framework version?',
@@ -91,12 +90,11 @@ module.exports = class extends yeoman {
 				}]
 		}];
 
-		var done = this.async();
-		this.prompt(questions).then(function(answers) {
+		this.prompt(questions).then((answers) => {
 			this.target = answers.target;
 			this._buildTemplateData();
 			done();
-		}.bind(this));
+		});
 	}
 
 	_buildTemplateData() {
@@ -109,21 +107,46 @@ module.exports = class extends yeoman {
 
 	_copyProjectItems() {
 		mkdir.sync(this.settings.ProjectPath);
-		if(this.settings.serialization)
-        {
-			this.fs.copyTpl(this.templatePath('_project.unicorn.csproj'), this.destinationPath(path.join(this.settings.ProjectPath, this.settings.LayerPrefixedProjectName + '.csproj')), this.templatedata);
+		if(this.settings.serialization) {
+			this.fs.copyTpl(
+				this.templatePath('_project.unicorn.csproj'),
+				this.destinationPath(
+					path.join(
+						this.settings.ProjectPath,
+						this.settings.LayerPrefixedProjectName + '.csproj')
+					),
+					this.templatedata
+				);
+		} else {
+			this.fs.copyTpl(
+				this.templatePath('_project.csproj'),
+				this.destinationPath(
+					path.join(
+						this.settings.ProjectPath,
+						this.settings.LayerPrefixedProjectName + '.csproj')
+					),
+					this.templatedata);
 		}
-		else
-        {
-			this.fs.copyTpl(this.templatePath('_project.csproj'), this.destinationPath(path.join(this.settings.ProjectPath, this.settings.LayerPrefixedProjectName + '.csproj')), this.templatedata);
-		}
-		this.fs.copyTpl(this.templatePath('Properties/AssemblyInfo.cs'), this.destinationPath(path.join(this.settings.ProjectPath, '/Properties/AssemblyInfo.cs')), this.templatedata);
-        
-        //if we have publishsettings.targets, then copy in PublishProfiles/local.pubxml
+		this.fs.copyTpl(
+			this.templatePath('Properties/AssemblyInfo.cs'),
+			this.destinationPath(
+				path.join(
+					this.settings.ProjectPath,
+					'/Properties/AssemblyInfo.cs')
+				),
+				this.templatedata
+			);
+
+			//if we have publishsettings.targets, then copy in PublishProfiles/local.pubxml
 		fs.access(this.destinationPath('publishsettings.targets'), fs.constants.R_OK, (err) => {
-			if(err==null)
-            {
-				this.fs.copyTpl(this.templatePath('Properties/PublishProfiles/local.pubxml'), this.destinationPath(path.join(this.settings.ProjectPath, 'Properties/PublishProfiles/local.pubxml')), this.templatedata);
+			if(err === null){
+				this.fs.copyTpl(
+					this.templatePath('Properties/PublishProfiles/local.pubxml'),
+					this.destinationPath(
+						path.join(this.settings.ProjectPath, 'Properties/PublishProfiles/local.pubxml')
+					),
+					this.templatedata
+				);
 			}
 		});
 	}
@@ -133,43 +156,53 @@ module.exports = class extends yeoman {
 	}
 
 	_renameProjectFile() {
-		fs.renameSync(this.destinationPath(path.join(this.settings.ProjectPath, '_project.csproj')), this.destinationPath(path.join(this.settings.ProjectPath, this.settings.LayerPrefixedProjectName + '.csproj')));
+		fs.renameSync(
+			this.destinationPath(
+				path.join(this.settings.ProjectPath, '_project.csproj')
+			),
+			this.destinationPath(
+				path.join(
+					this.settings.ProjectPath,
+					this.settings.LayerPrefixedProjectName + '.csproj'
+				)
+			)
+		);
 	}
 
-   
 	_copySerializationItems() {
 		mkdir.sync(path.join(this.settings.sourceFolder, this.layer, this.settings.ProjectName, 'serialization' ));
-		var serializationDestinationFile = path.join(this.settings.ProjectPath, 'App_Config/Include', this.settings.LayerPrefixedProjectName, 'serialization.config');
+		const serializationDestinationFile = path.join(
+			this.settings.ProjectPath,
+			'App_Config/Include',
+			this.settings.LayerPrefixedProjectName,
+			'serialization.config'
+		);
 		this.fs.copyTpl(this.templatePath('_serialization.config'), this.destinationPath(serializationDestinationFile), this.templatedata);
 	}
 
 	writing() {
 		this.settings.ProjectPath = path.join(this.settings.sourceFolder, this.layer, this.settings.ProjectName, 'code' );
-		this._copyProjectItems(); 
+		this._copyProjectItems();
 
-		if(this.settings.serialization)
-        {
+		if(this.settings.serialization) {
 			this._copySerializationItems();
 		}
 
-		if(fs.existsSync(this.destinationPath('helix-template')))
-        {
+		if(fs.existsSync(this.destinationPath('helix-template'))) {
 			this._copySolutionSpecificItems();
 		}
 
-		const files = fs.readdirSync( this.destinationPath());
+		const files = fs.readdirSync(this.destinationPath());
 		const SolutionFile = files.find(file => file.indexOf('.sln') > -1);
 		const scriptParameters = '-SolutionFile \'' + this.destinationPath(SolutionFile) + '\' -Name ' + this.settings.LayerPrefixedProjectName + ' -Type ' + this.layer + ' -ProjectPath \'' + this.settings.ProjectPath + '\'' + ' -SolutionFolderName ' + this.templatedata.projectname;
 
 		var pathToAddProjectScript = path.join(this._sourceRoot, '../../../powershell/add-project.ps1');
 		powershell.runAsync(pathToAddProjectScript, scriptParameters);
-
 	}
 
 	end() {
-		if(fs.existsSync(this.destinationPath('helix-template/_project.csproj')))
-        {
+		if(fs.existsSync(this.destinationPath('helix-template/_project.csproj'))){
 			this._renameProjectFile();
-		}}
+		}
+	}
 };
-


### PR DESCRIPTION
### Description of the Change

Use ES6 syntax as we already are depended on a version of nodejs taht
supports this. Also fix some formatting issues.

Fixes #66 by removing that line that did nothing.

### Possible Drawbacks

Could break something, please test it as well as merge #65 for the extra tests.