### PR TITLE
Automatically install dependencies when choosing solution with Pentia tools

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ end_of_line = lf
 insert_final_newline = true
 
 # JavaScript
-[{*.js}]
+[*.js]
 indent_style = tab
 
 # Styles

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -178,4 +178,10 @@ module.exports = class extends yeoman {
 			break;
 		}
 	}
+
+	installDependencies() {
+		if (this.type === 'pentiahelix') {
+			this.npmInstall();
+		}
+	}
 };

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -6,179 +6,176 @@ var path = require('path');
 
 module.exports = class extends yeoman {
 
-    constructor(args, opts) {
-        super(args, opts);
+	constructor(args, opts) {
+		super(args, opts);
 
-        this.option('solutionName', { type: String, required: false, desc: 'the name of the Helix solution' });
-    }
+		this.option('solutionName', { type: String, required: false, desc: 'the name of the Helix solution' });
+	}
 
-    init() {
-        this.log(yosay('Welcome to the kickass Helix generator!'));
-        this.templatedata = {};
-    }
+	init() {
+		this.log(yosay('Welcome to the kickass Helix generator!'));
+		this.templatedata = {};
+	}
 
-    askForSolutionType() {
-        var questions = [{
-        type: 'list',
+	askForSolutionType() {
+		var questions = [{
+			type: 'list',
 			name: 'SolutionType',
-        message: 'What type of solution do you want to create?',
+			message: 'What type of solution do you want to create?',
 			choices: [{
-            name: 'Empty Helix solution',
-            value: 'emptyhelix'
+				name: 'Empty Helix solution',
+				value: 'emptyhelix'
 			},{
-            name: 'Helix solution with Pentia tools',
-            value: 'pentiahelix'
-            }]
-        }];
+				name: 'Helix solution with Pentia tools',
+				value: 'pentiahelix'
+			}]
+		}];
 
-        var done = this.async();
+		var done = this.async();
 
-        this.prompt(questions).then(function(answers) {
+		this.prompt(questions).then(function(answers) {
 			this.type = answers.SolutionType;
 			this.includeWCT = answers.includeWCT;
-            done();
-        }.bind(this));
-    }
+			done();
+		}.bind(this));
+	}
 
-    askForSolutionSettings() {
-        var questions = [{
-                type: 'input',
-                name: 'SolutionName',
-                message: 'Name of your Helix solution',
-                default: this.appname
-            },
-            {
-                type:'input',
-                name:'sourceFolder',
-                message:'Source code folder name', 
-                default: 'src'
-            }];
+	askForSolutionSettings() {
+		var questions = [{
+			type: 'input',
+			name: 'SolutionName',
+			message: 'Name of your Helix solution',
+			default: this.appname
+		},
+		{
+			type:'input',
+			name:'sourceFolder',
+			message:'Source code folder name', 
+			default: 'src'
+		}];
 
-        var done = this.async();
-        this.prompt(questions).then(function(answers) {
-            this.settings = answers;
+		var done = this.async();
+		this.prompt(questions).then(function(answers) {
+			this.settings = answers;
 			this.sourceFolder = answers.sourceFolder;
 			this.SolutionName = answers.SolutionName;
-            done();
-        }.bind(this));
-    }
+			done();
+		}.bind(this));
+	}
 
-    askTargetFrameworkVersion() {
-        var questions = [{
-            type: 'list',
-            name: 'target',
-            message: 'Choose target .net framework version?',
-            choices: [
-                {
-                name: '.net 4.6.1',
-                value: 'v4.6.1'
-                }, {
-                name: '.net 4.6',
-                value: 'v4.6'
-                }, {
-                name: '.net 4.5.2',
-                value: 'v4.5.2'
-                }]
-            }];
+	askTargetFrameworkVersion() {
+		var questions = [{
+			type: 'list',
+			name: 'target',
+			message: 'Choose target .net framework version?',
+			choices: [
+				{
+					name: '.net 4.6.1',
+					value: 'v4.6.1'
+				}, {
+					name: '.net 4.6',
+					value: 'v4.6'
+				}, {
+					name: '.net 4.5.2',
+					value: 'v4.5.2'
+				}]
+		}];
 
-        var done = this.async();
-        this.prompt(questions).then(function(answers) {
-            this.target = answers.target;
-            done();
-        }.bind(this));
-    }
+		var done = this.async();
+		this.prompt(questions).then(function(answers) {
+			this.target = answers.target;
+			done();
+		}.bind(this));
+	}
 
 
-    askSiteUrl() {
-        var questions = [{
-                type: 'input',
-                name: 'LocalWebsiteUrl',
-                message: 'Enter the local website URL',
+	askSiteUrl() {
+		var questions = [{
+			type: 'input',
+			name: 'LocalWebsiteUrl',
+			message: 'Enter the local website URL',
 			default: 'http://'+ this.settings.SolutionName + '.local'
-            }];
-        var done = this.async();
-        this.prompt(questions).then(function(answers) {
-             this.localWebsiteUrl = answers.LocalWebsiteUrl;
-             this._buildTemplateData();
-            done();
-        }.bind(this));
-    }
+		}];
+		var done = this.async();
+		this.prompt(questions).then(function(answers) {
+			this.localWebsiteUrl = answers.LocalWebsiteUrl;
+			this._buildTemplateData();
+			done();
+		}.bind(this));
+	}
 
+	_buildTemplateData() {
+		this.templatedata.solutionname = this.settings.SolutionName;
+		this.templatedata.environmentguid = guid.v4();
+		this.templatedata.environmentfolderguid = guid.v4();
+		this.templatedata.projectguid = guid.v4();
+		this.templatedata.featureguid = guid.v4();
+		this.templatedata.foundationguid = guid.v4();
+		this.templatedata.testguid = guid.v4();
+		this.templatedata.sourceFolder = this.settings.sourceFolder;
+		this.templatedata.target = this.target;
+		this.templatedata.targetnoprefix = this.target.replace('v', '');
+		this.templatedata.localwebsiteurl = this.localWebsiteUrl;
+	}
 
-    _buildTemplateData() {
-        this.templatedata.solutionname = this.settings.SolutionName;
-        this.templatedata.environmentguid = guid.v4();
-        this.templatedata.environmentfolderguid = guid.v4();
-        this.templatedata.projectguid = guid.v4();
-        this.templatedata.featureguid = guid.v4();
-        this.templatedata.foundationguid = guid.v4();
-        this.templatedata.testguid = guid.v4();
-        this.templatedata.sourceFolder = this.settings.sourceFolder;
-        this.templatedata.target = this.target;
-        this.templatedata.targetnoprefix = this.target.replace('v','');
-        this.templatedata.localwebsiteurl = this.localWebsiteUrl;
-    }
+	_writeLayers() {
+		var layers = [ 'Project', 'Feature', 'Foundation'];
+			
+		for (var i = 0; i < layers.length; i++) {
+				
+			var destinationDirectory = path.join(this.settings.sourceFolder,layers[i]);
+			mkdir.sync(destinationDirectory);
 
+			var layer = layers[i];
+			var layerDocumentationFileName = layer + '/' + layer + '-layer.md';
+			var destinationFileName = path.join(this.destinationPath(destinationDirectory), layer + '-layer.md');
+			this.fs.copy(this.templatePath(layerDocumentationFileName),this.destinationPath(destinationFileName));
+		}
+	}
 
-    _writeLayers() {
-        var layers = [ 'Project', 'Feature', 'Foundation'];
-            
-            for(var i = 0; i < layers.length; i++) {
-                
-                var destinationDirectory = path.join(this.settings.sourceFolder,layers[i]);
-                mkdir.sync(destinationDirectory);
+	_copyEmptySolutionItems() {
+		this.fs.copyTpl(this.templatePath('_emptySolution.sln'), this.destinationPath(this.settings.SolutionName + '.sln'), this.templatedata);
+	}
 
-                var layer = layers[i];
-                var layerDocumentationFileName = layer + '/' + layer + '-layer.md';
-                var destinationFileName = path.join(this.destinationPath(destinationDirectory), layer + '-layer.md');
-                this.fs.copy(this.templatePath(layerDocumentationFileName),this.destinationPath(destinationFileName));
-            }
-    }
-
-    _copyEmptySolutionItems(){
-        this.fs.copyTpl(this.templatePath('_emptySolution.sln'), this.destinationPath(this.settings.SolutionName + ".sln"), this.templatedata);
-    }
-
-    _copyTemplateFile(template, destination)
-    {
+	_copyTemplateFile(template, destination) {
 		this.fs.copyTpl(
 			this.templatePath(template),
 			this.destinationPath(destination),
-            this.templatedata
+			this.templatedata
 		);
-    }
+	}
 
-    _copyToEnvironmentProject(template, destination){
-        var environmentDestination = path.join(this.settings.sourceFolder, 'Project/Environment');
-        this._copyTemplateFile(template,path.join(environmentDestination, destination));
-    }
+	_copyToEnvironmentProject(template, destination) {
+		var environmentDestination = path.join(this.settings.sourceFolder, 'Project/Environment');
+		this._copyTemplateFile(template,path.join(environmentDestination, destination));
+	}
 
-    _copyPentiaSolutionItems() {
-        mkdir.sync(path.join(this.settings.sourceFolder,"Project/Environment/Properties"));
+	_copyPentiaSolutionItems() {
+		mkdir.sync(path.join(this.settings.sourceFolder, 'Project/Environment/Properties'));
 
-        this._copyToEnvironmentProject('Project/Environment/web.config', 'web.config');
-        this._copyToEnvironmentProject('Project/Environment/packages.config', 'packages.config');
-        this._copyToEnvironmentProject('Project/Environment/Properties/AssemblyInfo.cs','Properties/AssemblyInfo.cs');
-        this._copyToEnvironmentProject('Project/Environment/Project.Environment.csproj','Project.Environment.csproj');
+		this._copyToEnvironmentProject('Project/Environment/web.config', 'web.config');
+		this._copyToEnvironmentProject('Project/Environment/packages.config', 'packages.config');
+		this._copyToEnvironmentProject('Project/Environment/Properties/AssemblyInfo.cs', 'Properties/AssemblyInfo.cs');
+		this._copyToEnvironmentProject('Project/Environment/Project.Environment.csproj', 'Project.Environment.csproj');
 
-        this._copyTemplateFile('_gulpfile.js', 'gulpfile.js');
-        this._copyTemplateFile('_solution.sln', this.settings.SolutionName + '.sln');
-        this._copyTemplateFile('_package.json','package.json');
-        this._copyTemplateFile('_publishsettings.targets', 'publishsettings.targets');
-        this._copyTemplateFile('_solution-config.json', 'solution-config.json');
-    }
+		this._copyTemplateFile('_gulpfile.js', 'gulpfile.js');
+		this._copyTemplateFile('_solution.sln', this.settings.SolutionName + '.sln');
+		this._copyTemplateFile('_package.json', 'package.json');
+		this._copyTemplateFile('_publishsettings.targets', 'publishsettings.targets');
+		this._copyTemplateFile('_solution-config.json', 'solution-config.json');
+	}
 
-    writing() {
-            this._writeLayers();
-            switch(this.type)
-            {
-                case 'emptyhelix':
-                    this._copyEmptySolutionItems()
-                break;
+	writing() {
+		this._writeLayers();
+		switch (this.type) {
+			
+		case 'emptyhelix':
+			this._copyEmptySolutionItems();
+			break;
 
-                case 'pentiahelix':
-                    this._copyPentiaSolutionItems()
-                break;
-            }
-        }
+		case 'pentiahelix':
+			this._copyPentiaSolutionItems();
+			break;
+		}
+	}
 };

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -29,13 +29,21 @@ module.exports = class extends yeoman {
 				name: 'Helix solution with Pentia tools',
 				value: 'pentiahelix'
 			}]
+		}, {
+			type: 'confirm',
+			name: 'installDeps',
+			message: 'Would you like to auto-install Pentia tools?',
+			default: true,
+			when: function(answers) {
+				return answers.SolutionType === 'pentiahelix';
+			}
 		}];
 
 		var done = this.async();
 
 		this.prompt(questions).then(function(answers) {
 			this.type = answers.SolutionType;
-			this.includeWCT = answers.includeWCT;
+			this.installDeps = answers.installDeps;
 			done();
 		}.bind(this));
 	}
@@ -180,7 +188,7 @@ module.exports = class extends yeoman {
 	}
 
 	installDependencies() {
-		if (this.type === 'pentiahelix') {
+		if (this.type === 'pentiahelix' && this.installDeps) {
 			this.npmInstall();
 		}
 	}


### PR DESCRIPTION
### Description of the Change

Added function to auto-install dependencies from NPM if the user chooses to scaffold a solution with Pentia tools.

### Benefits

Simplifies the process of getting the solution ready to use, the user doesn't have to issue `npm install` after running the generator.

### Possible Drawbacks

Users may not want dependencies automatically installing; in which case a prompt or switch option could be added to enable/disable this functionality.