### PR TITLE
Fixes #72 - added new template varaible

### DIFF
--- a/generators/add/Templates/_Serialization.config
+++ b/generators/add/Templates/_Serialization.config
@@ -11,7 +11,7 @@
 					dependencies="Foundation.*"
 				>
           <targetDataStore
-            physicalRootPath="$(featureFolder)\<%= projectname %>\$(configurationFolder)"
+            physicalRootPath="$(<%= lowercasedlayer %>Folder)\<%= projectname %>\$(configurationFolder)"
             useDataCache="false"
             type="Rainbow.Storage.SerializationFileSystemDataStore, Rainbow"
             singleInstance="true"

--- a/generators/add/index.js
+++ b/generators/add/index.js
@@ -104,6 +104,7 @@ module.exports = class extends yeoman {
 		this.templatedata.projectname = this.settings.ProjectName;
 		this.templatedata.projectguid = guid.v4();
 		this.templatedata.layer = this.layer;
+		this.templatedata.lowercasedlayer = this.layer.toLowerCase();;
 		this.templatedata.target = this.target;
 	}
 

--- a/test/test-add.js
+++ b/test/test-add.js
@@ -58,7 +58,12 @@ describe('yo helix:add', function () {
 			}).then(() => {
 
 				assert.file([
-					'./src/Feature/AddedProjectFeatureName/code/Feature.AddedProjectFeatureName.csproj'
+					'./src/Feature/AddedProjectFeatureName/code/Feature.AddedProjectFeatureName.csproj',
+					'./src/Feature/AddedProjectFeatureName/code/App_Config/Include/Feature.AddedProjectFeatureName/serialization.config'
+				]);
+
+				assert.fileContent([
+					['./src/Feature/AddedProjectFeatureName/code/App_Config/Include/Feature.AddedProjectFeatureName/serialization.config', /physicalRootPath="\$\(featureFolder\)\\AddedProjectFeatureName\\\$\(configurationFolder\)"/]
 				]);
 
 				done();


### PR DESCRIPTION
### Requirements

it now prefixes the variable in the serialization file correctly

### Description of the Change

added a templatedata variable with the layer name that was lower-cased to match sitecore's way f declaring varaibels

### Benefits

serialization file has the correct values.

