### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,15 +29,16 @@
   "dependencies": {
     "chalk": "^1.1.3",
     "mkdirp": "0.5.1",
+    "mocha": "^3.2.0",
     "uuid": "3.0.1",
-    "yeoman-generator": "1.0.1",
-    "yosay": "1.2.1"
+    "yeoman-generator": "^1.1.1",
+    "yosay": "^2.0.0"
   },
   "devDependencies": {
     "eslint": "^3.17.1",
     "mocha": "*",
     "object-assign": "^4.1.0",
-    "yeoman-assert": "^2.2.1",
+    "yeoman-assert": "^3.0.0",
     "yeoman-test": "^1.4.0"
   },
   "files": [


### PR DESCRIPTION
### Description of the Change

Updates dependecies.

yeoman-assert & yosay, dropped support for old nodejs, a version we
don't support anyway - easy upgrade.

yeoman-generator has minor fix, that does not affect us.

Lock down mocha version a bit more.

### Benefits

Keeps upgrading easy, by not being to far behind.

### Possible Drawbacks

None.