### PR TITLE
Test NodeJS LTS & Stable, both on x86 and x64

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,12 @@
 # Test against the latest version of this Node.js version
 environment:
-  nodejs_version: "6"
+  matrix:
+    - nodejs_version: "LTS"
+    - nodejs_version: "Stable"
+
+platform:
+  - x86
+  - x64
 
 # Install scripts. (runs after repo cloning)
 install:


### PR DESCRIPTION
### Description of the Change

This could help detect more issues, and will make the tests take a bit longer. Also we don't specify a version of node, but take the LTS branch and the stable branch, as it should be the only versions we support.


### Benefits

Testing more things! And correct node versions. Might help us detect #94.

### Possible Drawbacks

Longer build time.