### PR TITLE
Fix #94 - Powershell path issue

### DIFF
--- a/modules/Powershell.js
+++ b/modules/Powershell.js
@@ -8,7 +8,7 @@ class Powershell {
 	runAsync(pathToScriptFile, parameters) {
 		console.log('Powershell - running: ' + pathToScriptFile + ' ' + parameters);
 		var spawn = require('child_process').spawn;
-		var child = spawn('powershell.exe', [pathToScriptFile.replace(/ /g,'` '), parameters]);
+		var child = spawn('powershell.exe', [pathToScriptFile.replace(/(.+)/gi,'&(“$1”)'), parameters]);
 
 		child.stdout.setEncoding('utf8');
 		child.stderr.setEncoding('utf8');


### PR DESCRIPTION
This fixes #94 the powershell path issue by wrapping it with the safe `&(“”)`