### PR TITLE
Corrected vendor prefix

### DIFF
--- a/generators/add/index.js
+++ b/generators/add/index.js
@@ -47,7 +47,7 @@ module.exports = class extends yeoman {
 			name:'VendorPrefix',
 			message:'Enter optional vendor prefix',
 			default: this.options.VendorPrefix,
-			store: true
+			store: false
 		}
 		];
 


### PR DESCRIPTION
The vendor should not be stored, as then it is not possible to reset to empty.

fixes #103

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

### Description of the Change

After specifying a vendor it should be possible to create a module without a vendor being specified, but when store is set to true if you enter nothing it will default to the last specified vale.

### Benefits

can create a module without a vendor prefix, and have no empty dot!!!

### Possible Drawbacks

If you want to create a module with a vendor you have to enter it each time.