### PR TITLE
Add option for .NET 4.7 for helix:add

### DIFF
--- a/generators/app/utility.js
+++ b/generators/app/utility.js
@@ -2,6 +2,9 @@ const chalk = require('chalk');
 
 function getTargets() {
 return [{
+	name: '.net 4.7',
+	value: 'v4.7'
+}, {
 	name: '.net 4.6.1',
 	value: 'v4.6.1'
 }, {


### PR DESCRIPTION
### Description of the Change
This PR adds .NET 4.7 as an option to be selected as the framework target. 

### Benefits
Developers can choose .NET 4.7 as a target. At the moment they need to select a version and then manualy upgrade via Visual Studio.

### Possible Drawbacks
None.