### PR TITLE
Set the assembly GUID to a random UUID #112

### DIFF
--- a/generators/add/Templates/Properties/AssemblyInfo.cs
+++ b/generators/add/Templates/Properties/AssemblyInfo.cs
@@ -20,7 +20,7 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("f13cdc76-e69f-4f57-a03c-0e758e7b9ffc")]
+[assembly: Guid("<%= projectguid %>")]
 
 // Version information for an assembly consists of the following four values:
 //

--- a/generators/app/Templates/Project/Environment/Properties/AssemblyInfo.cs
+++ b/generators/app/Templates/Project/Environment/Properties/AssemblyInfo.cs
@@ -20,7 +20,7 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
-[assembly: Guid("f13cdc76-e69f-4f57-a03c-0e758e7b9ffc")]
+[assembly: Guid("<%= projectguid %>>")]
 
 // Version information for an assembly consists of the following four values:
 //


### PR DESCRIPTION
### Description of the Change
Issue #112 mentioned that the project guids are currently hard coded in the templates. This PR fixes that behavior by setting the assembly guid using the 'projectguid' variable already available.

To verify the guid is different per project you can run `npm test` and verify by checking the generated files.

### Benefits
The project file that is generated now has a unique assembly guid and issue #112 can be closed 😄

### Possible Drawbacks
None.