### PR TITLE
Find .sln with endsWith to find the correct file

### DIFF
--- a/generators/add/index.js
+++ b/generators/add/index.js
@@ -223,7 +223,7 @@ module.exports = class extends yeoman {
 		}
 
 		const files = fs.readdirSync(this.destinationPath());
-		const SolutionFile = files.find(file => file.indexOf('.sln') > -1);
+		const SolutionFile = files.find(file => file.toUpperCase().endsWith(".SLN"));
 		const scriptParameters = '-SolutionFile \'' + this.destinationPath(SolutionFile) + '\' -Name ' + this.settings.LayerPrefixedProjectName + ' -Type ' + this.layer + ' -ProjectPath \'' + this.settings.ProjectPath + '\'' + ' -SolutionFolderName ' + this.templatedata.projectname;
 
 		var pathToAddProjectScript = path.join(this._sourceRoot, '../../../powershell/add-project.ps1');


### PR DESCRIPTION
### Description of the Change
The current implementation uses `.indexOf` to find the solution (.sln) file. This does not work correctly when for example there is a ReSharper settings file in the root of the repository, Project.sln.DotSettings.

To overcome this issue I've changed it to use `endsWith`.

### Benefits
Only find .sln files and fixes #111 

### Possible Drawbacks
None?