### PR TITLE
Added option to create configs with projectname, not storing it as part of foldername

### DIFF
--- a/generators/add/Templates/_project.unicorn.csproj
+++ b/generators/add/Templates/_project.unicorn.csproj
@@ -60,7 +60,7 @@
     <Reference Include="System.EnterpriseServices" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="App_Config\Include\<%= layerprefixedprojectname %>\Serialization.config" />
+    <Content Include="App_Config\Include\<%= configlayername %>\<%= confignameprefix %>Serialization.config" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/generators/add/index.js
+++ b/generators/add/index.js
@@ -105,6 +105,35 @@ module.exports = class extends yeoman {
 		});
 	}
 
+	askForFolderStructure() {
+		const done = this.async();
+		const questions = [{
+			type: 'list',
+			name: 'configConvention',
+			message: 'What folder structure do you want to be applied on config files?',
+			choices: [
+				{
+					name: 'App_Config/Include/Layer/ProjectName.ConfigName.config?',
+					value: true
+				}, {
+					name: 'App_Config/Include/Layer.ProjectName/ConfigName.config?',
+					value: false
+				},
+			],
+		}];
+
+		this.prompt(questions).then((answers) => { 
+			if(answers.configConvention){
+				this.configLayerName = this.layer;
+				this.configNamePrefix = this.settings.ProjectName + '.';
+			}else{
+				this.configLayerName = this.layer + '.' + this.settings.ProjectName;
+				this.configNamePrefix = '';
+			}
+			done();
+		});
+	}
+
 	askTargetFrameworkVersion() {
 		const done = this.async();
 		const questions = [{
@@ -130,6 +159,9 @@ module.exports = class extends yeoman {
 		this.templatedata.layer = this.layer;
 		this.templatedata.lowercasedlayer = this.layer.toLowerCase();
 		this.templatedata.target = this.target;
+		this.templatedata.configlayername = this.configLayerName;
+		this.templatedata.confignameprefix = this.configNamePrefix;
+
 	}
 
 	_copyProjectItems() {
@@ -204,8 +236,8 @@ module.exports = class extends yeoman {
 		const serializationDestinationFile = path.join(
 			this.settings.ProjectPath,
 			'App_Config/Include',
-			this.settings.LayerPrefixedProjectName,
-			'serialization.config'
+			this.configLayerName,
+			this.configNamePrefix + 'Serialization.config'
 		);
 		this.fs.copyTpl(this.templatePath('_serialization.config'), this.destinationPath(serializationDestinationFile), this.templatedata);
 	}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-helix",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "yeoman generator for Helix style Sitecore projects",
   "main": "index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,8 @@ You can inject all the variables that the generator defines into your files usin
 * `layer`
 * `target`
 * `vendorprefix`
+* `configlayername`
+* `confignameprefix`
 
 ***Note***
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

### Description of the Change

I see that there is already similar pull request, but this one add feature as optional part.

The issue no. 1: (copied from @vhil PR)
When having module folders directly inside Include folder, the "Feature" folders are getting loaded before "Foundation" folders, because "e" goes before "o" alphabetically. As long as the number of features/foundations is unknown it is hard to control the order of layer loading.

Resolution: Create parent folders with layer names. Then you can set Layers order in layer.config


The issue no. 2:
Habitat project uses config structure convention as:
App_Config
-Include
--Layer
---FeatureName.ConfigName.config

When coming into this type of solution, using generator-helix for adding new project is time consuming as it not support this convention and after all you have to change it manually.

Resolution: Add option to create configs in habitat style. Then no manual changes are needed.


The issue no. 3:
When you check ShowConfig.aspx you cannot distinguish from where patch is comming, as showconfig displays only name of the config, not the whole path. Few features can share the same name of config like "serialization.config" so in case of huge amount of projects, it can be misleading.

Resoultion: Add FeatureName to config file. Then no confusion when detecting from where patch is comming.

![image](https://user-images.githubusercontent.com/6108118/51383611-3394cc00-1b1a-11e9-83ea-cfe1cdf6edfb.png)
### Benefits

Two conventions of storing configs when adding project.
No manual changes needed when project follows habitat.
Less confusion and time spent when detecting config file from ShowConfig.aspx feature.
Can easier control layer loading order.
Less mess inside App_Config/Include folder.

### Possible Drawbacks
Can't see any, as feature is optional, and user can follow old style while adding project.