### PR TITLE
FIX: Module Group, serialization #133

### DIFF
--- a/generators/add/index.js
+++ b/generators/add/index.js
@@ -200,13 +200,19 @@ module.exports = class extends yeoman {
 	}
 
 	_copySerializationItems() {
-		mkdir.sync(path.join(this.settings.sourceFolder, this.layer, this.settings.ProjectName, 'serialization' ));
+		if(this.modulegroup){
+			mkdir.sync(path.join(this.settings.sourceFolder, this.layer, this.modulegroup, this.settings.ProjectName, 'serialization' ));
+		}
+		else{
+			mkdir.sync(path.join(this.settings.sourceFolder, this.layer, this.settings.ProjectName, 'serialization' ));
+		}
 		const serializationDestinationFile = path.join(
 			this.settings.ProjectPath,
 			'App_Config/Include',
 			this.settings.LayerPrefixedProjectName,
 			'serialization.config'
 		);
+
 		this.fs.copyTpl(this.templatePath('_serialization.config'), this.destinationPath(serializationDestinationFile), this.templatedata);
 	}
 


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

### Description of the Change

Fixed issue with serialization folder not being created correctly when a module group is provided.

### Benefits

serialization folder will now be created under:

src/[Layer]/[Module Group]/[Project Name]/serialization

### Possible Drawbacks

none