### PR TITLE
fix unicon config

### DIFF
--- a/generators/add/Templates/_Serialization.config
+++ b/generators/add/Templates/_Serialization.config
@@ -11,7 +11,7 @@
 					dependencies="Foundation.*"
 				>
           <targetDataStore
-            physicalRootPath="$(<%= lowercasedlayer %>Folder)\<%= projectname %>\$(configurationFolder)"
+            physicalRootPath="$(<%= lowercasedlayer %>Folder)\<% if (modulegroup) { %><%= modulegroup %>\<% } %><%= projectname %>\$(configurationFolder)"
             useDataCache="false"
             type="Rainbow.Storage.SerializationFileSystemDataStore, Rainbow"
             singleInstance="true"

--- a/generators/add/index.js
+++ b/generators/add/index.js
@@ -130,6 +130,7 @@ module.exports = class extends yeoman {
 		this.templatedata.layer = this.layer;
 		this.templatedata.lowercasedlayer = this.layer.toLowerCase();
 		this.templatedata.target = this.target;
+		this.templatedata.modulegroup = this.modulegroup;
 	}
 
 	_copyProjectItems() {


### PR DESCRIPTION
### Requirements

Bug - when adding a project with a module group defined, the unicorn file does not have the correct physicalRootPath

### Description of the Change

Modified the default serialization that it checks if the there is a module group and if so modifies the physicalRootPath to match the file location.

Fixes #133

### Benefits

The unicorn config is correct and will find the serialization files.

### Possible Drawbacks

none