### PR TITLE
Add projectspecific files based on directory

### DIFF
--- a/generators/add/index.js
+++ b/generators/add/index.js
@@ -42,7 +42,7 @@ module.exports = class extends yeoman {
 		{
 			type: 'confirm',
 			name: 'generateBuildConfigs',
-			message: 'Should buildconfigurations be generated (should be deactivated if your .csproj templates already have build configurations)?',
+			message: 'Should build configurations be generated (should be deactivated if your .csproj templates already have build configurations)?',
 			default : true
 		},
 		{

--- a/generators/add/index.js
+++ b/generators/add/index.js
@@ -207,6 +207,31 @@ module.exports = class extends yeoman {
 			// copy template
 			else{				
 
+				// only copy the correct project file there are seperate project files for serialization enabled and disabled
+				if(file.toLowerCase().endsWith('.csproj'))
+				{
+					// serialization is disabled and the current file is the .csproj with serialization enabled
+					if(!this.settings.serialization && file.toLowerCase().endsWith('.unicorn.csproj'))
+					{
+						return;
+					}
+					// serialization is enabled and the current file is the .csproj with serialization disabled
+					if(this.settings.serialization && !file.toLowerCase().endsWith('.unicorn.csproj'))
+					{
+						return;
+					}
+					// serialization is enabled and the current file is the .csproj with serialization enabled 
+					if(this.settings.serialization && file.toLowerCase().endsWith('.unicorn.csproj'))
+					{	
+						// copy template but remove the unicorn suffix									
+						this.fs.copyTpl(
+							sourcePath + file, 
+							destinationPath + '/' + this._replaceTokensInFileName(file.replace("unicorn.", "")),
+							this.templatedata);
+						return;
+					} 
+				}
+
 				// only copy serialization.config if serialization is enabled
 				if(file.toLowerCase().endsWith('serialization.config'))
 				{

--- a/generators/add/index.js
+++ b/generators/add/index.js
@@ -189,10 +189,19 @@ module.exports = class extends yeoman {
 		files.forEach(file => {
 			
 			var destinationPath = this.settings.ProjectPath + '/' + adjustedPath;
-			// remember not to copy serialization file in _copySerializationItems() if a project specific one has been found
+			// if current file is the serialization.config rename it according to settings
 			if(file.toLowerCase().endsWith('serialization.config'))
 			{
-				usingCustomSerializationConfig = true;
+				this.fs.copyTpl(
+					sourcePath + file, 
+					destinationPath + this.layer + "." +  this.settings.ProjectName + "." + file,
+					this.templatedata);
+
+					// remember not to copy serialization file in _copySerializationItems() if a project specific one has been found
+					usingCustomSerializationConfig = true;
+					
+					return;
+					
 			}
 
 			// call this function recursively for child directories

--- a/generators/add/index.js
+++ b/generators/add/index.js
@@ -210,16 +210,12 @@ module.exports = class extends yeoman {
 				// only copy the correct project file there are seperate project files for serialization enabled and disabled
 				if(file.toLowerCase().endsWith('.csproj'))
 				{
-					// serialization is disabled and the current file is the .csproj with serialization enabled
-					if(!this.settings.serialization && file.toLowerCase().endsWith('.unicorn.csproj'))
+					// serialization is disabled and the current file is the .csproj with serialization enabled or serialization is enabled and the current file is the .csproj with serialization disabled
+					if(!this.settings.serialization && file.toLowerCase().endsWith('.unicorn.csproj') || this.settings.serialization && !file.toLowerCase().endsWith('.unicorn.csproj'))
 					{
 						return;
 					}
-					// serialization is enabled and the current file is the .csproj with serialization disabled
-					if(this.settings.serialization && !file.toLowerCase().endsWith('.unicorn.csproj'))
-					{
-						return;
-					}
+
 					// serialization is enabled and the current file is the .csproj with serialization enabled 
 					if(this.settings.serialization && file.toLowerCase().endsWith('.unicorn.csproj'))
 					{	
@@ -233,14 +229,14 @@ module.exports = class extends yeoman {
 				}
 
 				// only copy serialization.config if serialization is enabled
+				if(file.toLowerCase().endsWith('serialization.config') && !this.settings.serialization)
+				{
+					return;
+				}
+
+				// remember not to copy serialization file in _copySerializationItems() if a project specific one has been found
 				if(file.toLowerCase().endsWith('serialization.config'))
 				{
-					if (!this.settings.serialization)
-					{
-						return;					
-					}
-
-					// remember not to copy serialization file in _copySerializationItems() if a project specific one has been found
 					usingCustomSerializationConfig = true;				
 				}
 

--- a/generators/add/index.js
+++ b/generators/add/index.js
@@ -212,16 +212,25 @@ module.exports = class extends yeoman {
 				var childPath = path + file + '/';
 				var adjustedChildPath = path;
 				
-				// remame Layer folder to the selected layer
-				if(file == 'Layer')
+				// remame setting dependent folders
+				switch(file)
 				{
-					destinationPath = destinationPath + '/' + this.layer;
-					adjustedChildPath += this.layer +'/';
-				}
-				else
-				{
-					destinationPath = destinationPath + '/' + file;
-					adjustedChildPath += file +'/';
+					case 'Layer':
+						destinationPath = destinationPath + '/' + this.layer;
+						adjustedChildPath += this.layer +'/';
+						break;
+					case 'ProjectName':
+						destinationPath = destinationPath + '/' + this.settings.ProjectName;
+						adjustedChildPath += this.settings.ProjectName +'/';
+						break;
+					case 'VendorPrefix':
+						destinationPath = destinationPath + '/' + this.settings.VendorPrefix;
+						adjustedChildPath += this.settings.VendorPrefix +'/';
+						break;
+					default:
+						destinationPath = destinationPath + '/' + file;
+						adjustedChildPath += file +'/';
+
 				}
 				
 				fs.mkdirSync(this.destinationPath(destinationPath));

--- a/generators/add/index.js
+++ b/generators/add/index.js
@@ -228,7 +228,7 @@ module.exports = class extends yeoman {
 					}
 					return;
 				}				
-				
+
         // if serialization is enabled, do not copy the project file which
         // does not contain any serialization configurations (according to file ending)
         if (file.toLowerCase().endsWith('.csproj') && this._serializationIsEnabled())
@@ -271,20 +271,28 @@ module.exports = class extends yeoman {
 		return filename;
 	}
 
-	_renameProjectFile() {
-		fs.renameSync(
-			this.destinationPath(
-				path.join(this.settings.ProjectPath, '_project.csproj')
-			),
-			this.destinationPath(
-				path.join(
-					this.settings.ProjectPath,
-					this.settings.LayerPrefixedProjectName + '.csproj'
-				)
-			)
-		);
-	}
+	_renameProjectFile() {		
+		// select correct .csproj file to rename depending on whether or not serialization is enabled
+		var filename = '_project.csproj';
+		if (this._serializationIsEnabled())
+		{
+			filename = '_project.unicorn.csproj'
+		}
 
+		if(fs.existsSync(this.destinationPath('helix-template/' + filename))){
+			fs.renameSync(
+				this.destinationPath(
+					path.join(this.settings.ProjectPath, '_project.csproj')
+				),
+				this.destinationPath(
+					path.join(
+						this.settings.ProjectPath,
+						this.settings.LayerPrefixedProjectName + '.csproj'
+					)
+				)
+			);
+		}
+	}
 	_copySerializationItems() {
 		if(this.modulegroup){
 			mkdir.sync(path.join(this.settings.sourceFolder, this.layer, this.modulegroup, this.settings.ProjectName, 'serialization' ));
@@ -322,15 +330,13 @@ module.exports = class extends yeoman {
 		
 		const files = fs.readdirSync(this.destinationPath());
 		const SolutionFile = files.find(file => file.toUpperCase().endsWith(".SLN"));
-		const scriptParameters = '-SolutionFile \'' + this.destinationPath(SolutionFile) + '\' -Name ' + this.settings.LayerPrefixedProjectName + ' -Type ' + this.layer + ' -ProjectPath \'' + this.settings.ProjectPath + '\'' + ' -SolutionFolderName ' + this.templatedata.projectname + '\'' + ' -GenerateBuildConfigs ' + this.settings.generateBuildConfigs;
+		const scriptParameters = '-SolutionFile \'' + this.destinationPath(SolutionFile) + '\' -Name ' + this.settings.LayerPrefixedProjectName + ' -Type ' + this.layer + ' -ProjectPath \'' + this.settings.ProjectPath + '\'' + ' -SolutionFolderName \'' + this.templatedata.projectname + '\'' + ' -GenerateBuildConfigs ' + this.settings.generateBuildConfigs;
 
 		var pathToAddProjectScript = path.join(this._sourceRoot, '../../../powershell/add-project.ps1');
 		powershell.runAsync(pathToAddProjectScript, scriptParameters);
 	}
 
 	end() {
-		if(fs.existsSync(this.destinationPath('helix-template/_project.csproj'))){
-			this._renameProjectFile();
-		}
+		this._renameProjectFile();
 	}
 };

--- a/generators/add/index.js
+++ b/generators/add/index.js
@@ -42,7 +42,7 @@ module.exports = class extends yeoman {
 		{
 			type: 'confirm',
 			name: 'generateBuildConfigs',
-			message: 'Should build configurations be generated (should be deactivated if your .csproj templates already have build configurations)?',
+			message: 'Should build configurations be generated (should be deactivated if your .csproj templates already provide build configurations)?',
 			default : true
 		},
 		{
@@ -273,11 +273,7 @@ module.exports = class extends yeoman {
 
 	_renameProjectFile() {		
 		// select correct .csproj file to rename depending on whether or not serialization is enabled
-		var filename = '_project.csproj';
-		if (this._serializationIsEnabled())
-		{
-			filename = '_project.unicorn.csproj'
-		}
+		var filename = (this._serializationIsEnabled()) ? '_project.unicorn.csproj' : '_project.csproj';
 
 		if(fs.existsSync(this.destinationPath('helix-template/' + filename))){
 			fs.renameSync(
@@ -330,7 +326,8 @@ module.exports = class extends yeoman {
 		
 		const files = fs.readdirSync(this.destinationPath());
 		const SolutionFile = files.find(file => file.toUpperCase().endsWith(".SLN"));
-		const scriptParameters = '-SolutionFile \'' + this.destinationPath(SolutionFile) + '\' -Name ' + this.settings.LayerPrefixedProjectName + ' -Type ' + this.layer + ' -ProjectPath \'' + this.settings.ProjectPath + '\'' + ' -SolutionFolderName \'' + this.templatedata.projectname + '\'' + ' -GenerateBuildConfigs ' + this.settings.generateBuildConfigs;
+		var generateBuildConfigs = this.settings.generateBuildConfigs.toLowerCase == 'true';
+		const scriptParameters = '-SolutionFile \'' + this.destinationPath(SolutionFile) + '\' -Name ' + this.settings.LayerPrefixedProjectName + ' -Type ' + this.layer + ' -ProjectPath \'' + this.settings.ProjectPath + '\'' + ' -SolutionFolderName \'' + this.templatedata.projectname + '\'' + ' -GenerateBuildConfigs ' + `$${this.settings.generateBuildConfigs}`;
 
 		var pathToAddProjectScript = path.join(this._sourceRoot, '../../../powershell/add-project.ps1');
 		powershell.runAsync(pathToAddProjectScript, scriptParameters);

--- a/generators/add/index.js
+++ b/generators/add/index.js
@@ -40,7 +40,12 @@ module.exports = class extends yeoman {
 			default : true
 		},
 		{
-			type:'input',
+			type: 'confirm',
+			name: 'generateBuildConfigs',
+			message: 'Should buildconfigurations be generated (should be deactivated if your .csproj templates already have build configurations)?',
+			default : true
+		},
+		{			type:'input',
 			name:'sourceFolder',
 			message:'Source code folder name',
 			default: 'src',
@@ -309,7 +314,7 @@ module.exports = class extends yeoman {
 		
 		const files = fs.readdirSync(this.destinationPath());
 		const SolutionFile = files.find(file => file.toUpperCase().endsWith(".SLN"));
-		const scriptParameters = '-SolutionFile \'' + this.destinationPath(SolutionFile) + '\' -Name ' + this.settings.LayerPrefixedProjectName + ' -Type ' + this.layer + ' -ProjectPath \'' + this.settings.ProjectPath + '\'' + ' -SolutionFolderName ' + this.templatedata.projectname;
+		const scriptParameters = '-SolutionFile \'' + this.destinationPath(SolutionFile) + '\' -Name ' + this.settings.LayerPrefixedProjectName + ' -Type ' + this.layer + ' -ProjectPath \'' + this.settings.ProjectPath + '\'' + ' -SolutionFolderName ' + this.templatedata.projectname + '\'' + ' -GenerateBuildConfigs ' + this.settings.generateBuildConfigs;
 
 		var pathToAddProjectScript = path.join(this._sourceRoot, '../../../powershell/add-project.ps1');
 		powershell.runAsync(pathToAddProjectScript, scriptParameters);

--- a/powershell/Add-Project.ps1
+++ b/powershell/Add-Project.ps1
@@ -36,7 +36,7 @@ $addProjectSolutionFolder = @("Project(`"{2150E333-8FDC-42A3-9474-1A3956D46DE8}`
 $addNestProjectSection = @("`t`t{$projectGuid} = {$projectFolderGuid}")
 $addNestProjectSolutionFolderSection = @("`t`t{$projectFolderGuid} = $solutionFolderId")
 
-Add-BuildConfigurations -ProjectPath $projectPath -Configurations $configurations                
+#Add-BuildConfigurations -ProjectPath $projectPath -Configurations $configurations                
 Add-Line -FileName $SolutionFile -Pattern $ProjectSection -LinesToAdd $addProjectSection
 Add-Line -FileName $SolutionFile -Pattern $ProjectSection -LinesToAdd $addProjectSolutionFolder
 Add-Line -FileName $SolutionFile -Pattern $NestedProjectSection -LinesToAdd $addNestProjectSection

--- a/powershell/Add-Project.ps1
+++ b/powershell/Add-Project.ps1
@@ -9,7 +9,9 @@ param(
 [Parameter(Mandatory=$true)]
 [string]$ProjectPath,
 [Parameter(Mandatory=$true)]
-[string]$SolutionFolderName)
+[string]$SolutionFolderName,
+[Parameter(Mandatory=$true)]
+[bool]$GenerateBuildConfigs)
 
 . $PSScriptRoot\Add-Line.ps1
 . $PSScriptRoot\Get-SolutionConfigurations.ps1
@@ -36,7 +38,9 @@ $addProjectSolutionFolder = @("Project(`"{2150E333-8FDC-42A3-9474-1A3956D46DE8}`
 $addNestProjectSection = @("`t`t{$projectGuid} = {$projectFolderGuid}")
 $addNestProjectSolutionFolderSection = @("`t`t{$projectFolderGuid} = $solutionFolderId")
 
-#Add-BuildConfigurations -ProjectPath $projectPath -Configurations $configurations                
+if ($GenerateBuildConfigs) {  
+  Add-BuildConfigurations -ProjectPath $projectPath -Configurations $configurations                
+}               
 Add-Line -FileName $SolutionFile -Pattern $ProjectSection -LinesToAdd $addProjectSection
 Add-Line -FileName $SolutionFile -Pattern $ProjectSection -LinesToAdd $addProjectSolutionFolder
 Add-Line -FileName $SolutionFile -Pattern $NestedProjectSection -LinesToAdd $addNestProjectSection

--- a/powershell/Get-SolutionFolderId.ps1
+++ b/powershell/Get-SolutionFolderId.ps1
@@ -11,6 +11,6 @@ Function Get-SolutionFolderId {
     $msbuildPath = Get-MSBuildPath
     Add-Type -Path "$msbuildPath\Microsoft.Build.dll"
     $solution = [Microsoft.Build.Construction.SolutionFile]::Parse($SolutionFile)
-    $solution.ProjectsInOrder| where-object {$_.ProjectType -eq [Microsoft.Build.Construction.SolutionProjectType]::SolutionFolder } | where-object {$_.ProjectName -like "*$type*"} | Select-Object -ExpandProperty ProjectGuid
+    $solution.ProjectsInOrder| where-object {$_.ProjectType -eq [Microsoft.Build.Construction.SolutionProjectType]::SolutionFolder } | where-object {$_.ProjectName -like "*$type*"} | Select-Object -Index 0 | Select-Object -ExpandProperty ProjectGuid
 }
 


### PR DESCRIPTION
### Description of the Change

This change addresses a few issues I had with the generator. I realize that there is another pending pull request that adresses part of the Problem, but I believe this solution is more customizeable. I had most of the implementation finished before I saw this request, so I thought it's worth to give it a shot:


#### 1. Make more use of the helix-template folder in the project

With this change the helix generator makes more use of the `helix-template` folder in the solution.
This means, that every file and every folder that is contained in the `helix-template` folder will be copied to the `code` folder of the module which is being created. While copying the structure of the `helix-template` folder, the substings `_Layer`, `_Module` and `_Vendor` in filenames and folder names will be replaced by the current values.


#### 2. Build config generation in .csproj file can be deactivated

I added the option to not generate build configurations in the `.csproj` file. There is an additional question if build configurations should be generated on script start which controls this. This is useful if there are specific needs to the build configurations which aren't handled by the generator yet. To use this correctly the build configurations should be provided by the `.csproj` templates.


#### 3. Bugfix

In addition to the above features, I fixed a bug, that could cause a broken solution file. This bug occurred when there were Modules in the solution that contained the name of a Layer, but were not the Layer folder.

For example a solution that had a module which is called `FeatureList` would cause the created project to have two parent items in the nested projects section, the `FeatureList` and the Layer folder itself.
So in the solution file there would be an assignment like this:

```
{AA5E14BE-163F-49CF-AB86-83F0B9F11787} = {A6A46CA0-6EE6-4964-9D5B-83163E178A7E}{60DA3F20-DEED-4580-AE38-A296D76ADE79}
```
To fix this, I changed the generator to only pick the first object that is found with the @like@ operation. So if a solution does have this problem it can be resolved by moving the layer folders to the top of the project definitions in the.sln file.

### Benefits

* More options to adjust the generator to the needs of a specific solution.
* For most solutions there should be no manual adjustments neccessary after the project is created, assuming the `helix-template` folder is set up correct.
* Problems with Modules which have a name of a layer as part of their own name can be avoided.

### Possible Drawbacks

* Wrong content of Files in the `helix-template` folder of the solution might break the solution
* There is an additional question on script startup, which might confuse users on first use